### PR TITLE
Dependencies problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "An ARQ initiative.",
   "dependencies": {
-    "keystone":"https://github.com/keystonejs/keystone.git#master",
+    "keystone":"0.3.15",
     "async": "^1.5.0",
     "underscore": "^1.8.3",
     "node-sass": "^3.3.2",


### PR DESCRIPTION
The last version of keystone has dependencies problems between history@2.0.0 and history@1.17.0. 

To solve this problem I change the package.json to use the 0.3.15 version of keystone. Also, with change, everyone will use the same version of keystone and it won't depend of what changes are pushed on the master branch in keystone repository
