### PR TITLE
#21 add testing dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,17 +6,18 @@ var watch = require('gulp-watch');
 var shell = require('gulp-shell');
 var open = require('gulp-open');
 var sass = require('gulp-sass');
+var jasmine = require('gulp-jasmine');
 var runSequence = require('run-sequence');
 
 var paths = {
-	'src':['./models/**/*.js','./routes/**/*.js', 'keystone.js', 'package.json']
-
-,
+	'src':['./models/**/*.js','./routes/**/*.js', 'keystone.js', 'package.json'],
 	'style': {
 		all: './public/styles/**/*.scss',
 		output: './public/styles/'
+	},
+	'test': {
+		'routes': 'test/routes/**/*[sS]pec.js'
 	}
-
 };
 
 var browser = os.platform() === 'linux' ? 'google-chrome' : (
@@ -49,6 +50,16 @@ gulp.task('sass', 'Compile sass.', function(){
 gulp.task('start', 'Run keystonejs-portal.', shell.task('node keystone.js'));
 
 gulp.task('start-dev', 'Run keystonejs-portal with nodemon watching changes in js files.', shell.task('nodemon --watch ./routes --watch ./models keystone.js'));
+
+gulp.task('test', 'Run all project tests', ['test:routes']);
+
+gulp.task('test:routes', 'Runs routes tests', function () {
+	return gulp.src(paths.test.routes)
+		.pipe(jasmine({
+			timeout: 15000
+		}));
+});
+
 
 gulp.task('openBrowser', 'Open browser with default URL to access.', function(){
 	var config = { app: browser, uri: 'http://localhost:3000'};

--- a/keystone.js
+++ b/keystone.js
@@ -97,3 +97,5 @@ keystone.set('nav', {
 // Start Keystone to connect to your database and initialise the web server
 
 keystone.start();
+
+module.exports = keystone;

--- a/package.json
+++ b/package.json
@@ -4,25 +4,28 @@
   "private": true,
   "description": "An ARQ initiative.",
   "dependencies": {
-    "keystone": "https://github.com/keystonejs/keystone.git#master",
     "async": "^1.5.0",
-    "underscore": "^1.8.3",
+    "dotenv": "^1.1.0",
+    "keystone": "https://github.com/keystonejs/keystone.git#master",
     "node-sass": "^3.4.2",
     "node-sass-middleware": "^0.9.7",
-    "dotenv": "^1.1.0"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-help": "^1.6.1",
+    "gulp-jasmine": "^2.2.1",
     "gulp-jshint": "^2.0.0",
     "gulp-open": "^1.0.0",
     "gulp-sass": "^2.1.1",
     "gulp-shell": "^0.5.0",
     "gulp-wait": "0.0.2",
     "gulp-watch": "^4.3.5",
+    "jasmine": "^2.4.1",
     "jshint-stylish": "^0.1.3",
     "nodemon": "^1.8.1",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "supertest": "^1.2.0"
   },
   "engines": {
     "node": ">=0.10.22",
@@ -30,7 +33,8 @@
   },
   "scripts": {
     "start": "node keystone.js",
-    "start-dev": "nodemon --watch ./routes --watch ./models keystone.js"
+    "start-dev": "nodemon --watch ./routes --watch ./models keystone.js",
+    "test": "gulp test"
   },
   "main": "keystone.js"
 }

--- a/test/helpers/keystone/index.js
+++ b/test/helpers/keystone/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var keystone = require('../../../keystone.js');
+
+const port = process.env.TEST_PORT || 5150;
+keystone.set('port', port);
+
+module.exports = keystone;

--- a/test/routes/home.spec.js
+++ b/test/routes/home.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var request     = require('supertest'),
+	keystone    = require('../helpers/keystone');
+
+const app   = keystone.app;
+const route = '/';
+
+describe('Home route', () => {
+	
+	it('should not return an error', (done) => {
+		request(app)
+			.get(route)
+			.expect(200)
+			.end((err, res) => {
+				if (err) return done(err);
+				
+				expect(err).toBeNull();
+				expect(res.body).not.toBeNull();
+				expect(res.ok).toBeTruthy();
+
+				done();
+			});
+		
+	});
+	
+	afterAll(() => {
+		keystone.httpServer.close();
+		keystone.mongoose.connection.close();
+	});
+	
+});


### PR DESCRIPTION
Pull request due to issue #21. 

For the moment, in my opinion we just need `jasmine` as testing framework, as we can test both front-end and back-end code.

Also created a simple test spec to test "home" route.
