### PR TITLE
Feature/#11 i18n module

### DIFF
--- a/keystone.js
+++ b/keystone.js
@@ -2,8 +2,9 @@
 // customising the .env file in your project's root folder.
 require('dotenv').load();
 
-// Require keystone
-var keystone = require('keystone');
+var keystone    = require('keystone'),
+	i18n        = require('i18n'),
+	path        = require('path');
 
 // Initialise Keystone with your project's configuration.
 // See http://keystonejs.com/guide/config for available options
@@ -44,8 +45,38 @@ keystone.set('locals', {
 	editable: keystone.content.editable
 });
 
-// Load your project's Routes
+// global i18n configuration
+var i18nConfig = {
+	supportedLocales: ['en', 'es'],
+	defaultLocale: 'en',
+	queryName: 'lang',
+	cookie: {
+		name: 'language',
+		options: { maxAge: 24 * 3600 * 1000},
+		changeLocaleUrl: '/languages/{language}' 
+	}
+};
 
+// i18n configuration
+i18n.configure({
+	locales         : i18nConfig.supportedLocales,
+	defaultLocale   : i18nConfig.defaultLocale,
+	cookie          : i18nConfig.cookie.name,
+	directory       : path.join(__dirname, 'locales'),
+	objectNotation  : true,
+	updateFiles     : false
+});
+
+// keystone language options
+keystone.set('language options', {
+	'supported languages'       : i18nConfig.supportedLocales,
+	'language query name'       : i18nConfig.queryName,
+	'language cookie'           : i18nConfig.cookie.name,
+	'language cookie options'   : i18nConfig.cookie.options,
+	'language select url'       : i18nConfig.cookie.changeLocaleUrl
+});
+
+// Load your project's Routes
 keystone.set('routes', require('./routes'));
 
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "home": {
+    "welcome": "Welcome"
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,5 @@
+{
+  "home": {
+    "welcome": "Bienvenidos"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "dotenv": "^1.1.0",
+    "i18n": "^0.7.0",
     "keystone": "https://github.com/keystonejs/keystone.git#master",
     "node-sass": "^3.4.2",
     "node-sass-middleware": "^0.9.7",

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,9 +18,15 @@
  * http://expressjs.com/api.html#app.VERB
  */
 
-var keystone = require('keystone');
-var middleware = require('./middleware');
+var keystone    = require('keystone'),
+	i18n        = require('i18n'),
+	middleware  = require('./middleware');
+
 var importRoutes = keystone.importer(__dirname);
+
+// Add i18n API implementation
+keystone.pre('routes', i18n.init);
+keystone.set('i18n', i18n);
 
 // Common Middleware
 keystone.pre('routes', middleware.initLocals);

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -31,6 +31,7 @@ exports.initLocals = function(req, res, next) {
 	];
 	
 	locals.user = req.user;
+	locals.language = req.language;
 	
 	next();
 	

--- a/templates/layouts/default.jade
+++ b/templates/layouts/default.jade
@@ -1,7 +1,7 @@
 include ../mixins/flash-messages
 
 doctype html
-html
+html(lang="#{language}")
 
 	//- HTML HEADER
 	head
@@ -65,6 +65,15 @@ html
 							each link in navLinks
 								li(class=(section == link.key ? 'active' : null)): a.waves-effect.waves-light(href=link.href)= link.label
 						ul.nav.navbar-nav.navbar-right
+							li.dropdown
+								a.dropdown-toggle.waves-effect.waves-light(data-toggle="dropdown", role="button") Language
+									span.caret
+								ul.dropdown-menu(role="menu")
+									li
+										a(href="?lang=en") English
+										a(href="?lang=es") Español
+										
+									
 							if user
 								if user.canAccessKeystone
 									li: a.waves-effect.waves-light(href='/keystone') Open Keystone

--- a/templates/views/index.jade
+++ b/templates/views/index.jade
@@ -3,7 +3,7 @@ extends ../layouts/default
 block content
 	.container: .jumbotron
 		img(src='/images/logo.svg', width='160')
-		h1 Welcome
+		h1 #{__('home.welcome')}
 		p This is your new <a href='http://keystonejs.com' target='_blank'>KeystoneJS</a> website.
 		p It includes the latest versions of
 			| <a href='http://getbootstrap.com/' target='_blank'>Bootstrap</a>

--- a/test/helpers/keystone/index.js
+++ b/test/helpers/keystone/index.js
@@ -5,4 +5,12 @@ var keystone = require('../../../keystone.js');
 const port = process.env.TEST_PORT || 5150;
 keystone.set('port', port);
 
+/**
+ * Closes keystone http server and mongodb connections.
+ */
+keystone.closeConnections = () => {
+	keystone.httpServer.close();
+	keystone.mongoose.connection.close();
+};
+
 module.exports = keystone;

--- a/test/routes/home.spec.js
+++ b/test/routes/home.spec.js
@@ -13,7 +13,7 @@ describe('Home route', () => {
 			.get(route)
 			.expect(200)
 			.end((err, res) => {
-				if (err) return done(err);
+				if (err) return done.fail(err);
 				
 				expect(err).toBeNull();
 				expect(res.body).not.toBeNull();

--- a/test/routes/home.spec.js
+++ b/test/routes/home.spec.js
@@ -24,9 +24,6 @@ describe('Home route', () => {
 		
 	});
 	
-	afterAll(() => {
-		keystone.httpServer.close();
-		keystone.mongoose.connection.close();
-	});
+	afterAll(keystone.closeConnections);
 	
 });

--- a/test/routes/language.spec.js
+++ b/test/routes/language.spec.js
@@ -1,0 +1,80 @@
+'use strict';
+
+var request     = require('supertest'),
+	keystone    = require('../helpers/keystone');
+
+const app           = keystone.app;
+const defaultLocale = keystone.get('i18n').getLocale();
+
+/**
+ * @param language
+ * @returns {string} Language route using string interpolation.
+ */
+var getRoute = (language) => {
+	return `/languages/${language}`;	
+};
+
+/**
+ * TODO all todo's in this test must be removed as soon as this issue is fixed:
+ * @link {https://github.com/tinganho/express-request-language/issues/5}
+ */
+describe('Language route', () => {
+	
+	it('must not change language without request param', (done) => {
+		
+		request(app)
+			.get(getRoute(''))
+			.expect(302)
+			.expect('Location', '/')
+			// TODO check langauge cookie value is the default locale
+			// .expect('set-cookie', new RegExp(`language=${defaultLocale}`, 'g'))
+			.end((err, res) => {
+				if (err) return done.fail(err);
+				
+				expect(err).toBeNull();
+				expect(res.body).not.toBeNull();
+				
+				done();
+			});
+	});
+	
+	it('must not change language when requested an unsupported language', (done) => {
+		
+		request(app)
+			.get(getRoute('de'))
+			.expect(302)
+			.expect('Location', '/')
+			// TODO check langauge cookie value is the default locale
+			// .expect('set-cookie', new RegExp(`language=${defaultLocale}`, 'g'))
+			.end((err, res) => {
+				if (err) return done.fail(err);
+				
+				expect(err).toBeNull();
+				expect(res.body).not.toBeNull();
+				
+				done();
+			});
+		
+	});
+	
+	it('must change language when requested a supported language', (done) => {
+		
+		request(app)
+			.get(getRoute('es'))
+			.expect(302)
+			.expect('Location', '/')
+			.expect('set-cookie', /language=es/)
+			.end((err, res) => {
+				if (err) return done.fail(err);
+				
+				expect(err).toBeNull();
+				expect(res.body).not.toBeNull();
+				
+				done();
+			});
+		
+	});
+
+	afterAll(keystone.closeConnections);
+	
+});


### PR DESCRIPTION
Integrates `i18n` API implementation with Keystone language resolver.

Two locales are added for the moment: English (default) and Spanish.

Also adds a dropdown menu to website navbar in order to change language via query parameter (ie: `/blog?lang=es`), so language can be changed from any page. :lollipop:

Finally, adds some integration tests between `/language/{language}` route (provided by https://github.com/tinganho/express-request-language module) and application's `i18n` instance.
- **Notice**: opened issue https://github.com/tinganho/express-request-language/issues/5 because apparently this module has a vulnerability on setting cookie values from the request parameter. 
